### PR TITLE
feat: Add FROG report generation to workflows (Resolves #21)

### DIFF
--- a/docs/source/cmpb/about-pipeline.rst
+++ b/docs/source/cmpb/about-pipeline.rst
@@ -53,7 +53,7 @@ The following steps are executed in the workflow:
   - Model statistics
   - Analysing growth
   - Testing for amino acid auxotrophies
-  - Optionally: Analysing with ``FROG`` (future update)
+  - Optionally: Analysing with ``FROG``
   - Optionally: Analysing with ``MEMOTE``
 
 | For each step the model version and, optionally, the according ``MEMOTE`` report can be saved.

--- a/src/specimen/data/config/hqtb_advanced_config_expl.yaml
+++ b/src/specimen/data/config/hqtb_advanced_config_expl.yaml
@@ -203,6 +203,8 @@ parameters:
         test_aa_auxotrophies: True
         # perform pathway analysis with KEGG
         pathway: True
+        # generate a FROG report for the final model
+        frog: False
 
 ########## technical params ##########
 performance:

--- a/src/specimen/data/config/hqtb_basic_config_expl.yaml
+++ b/src/specimen/data/config/hqtb_basic_config_expl.yaml
@@ -145,6 +145,15 @@ parameters:
         dna_weight_frac: 0.023
         ion_weight_frac: 0.05
 
-    ########## step 5: analysis ##########   
+    ########## step 5: analysis ##########
     analysis:
-        media_analysis: __USER__
+        # How to compare to pan-core model (current option only id)
+        pc_based_on: id
+        # simulate growth on different media (media config file (refineGEMs) required)
+        media_analysis: __USER__ 
+        # test for amino acid auxotrophies
+        test_aa_auxotrophies: True
+        # perform pathway analysis with KEGG
+        pathway: True
+        # generate a FROG report for the final model
+        frog: False

--- a/src/specimen/data/config/hqtb_config_default.yaml
+++ b/src/specimen/data/config/hqtb_config_default.yaml
@@ -205,6 +205,8 @@ parameters:
         test_aa_auxotrophies: True
         # perform pathway analysis with KEGG
         pathway: True
+        # generate a FROG report for the final model
+        frog: False
 
 ########## technical params ##########
 performance:

--- a/src/specimen/hqtb/core/analysis.py
+++ b/src/specimen/hqtb/core/analysis.py
@@ -40,6 +40,7 @@ logger.propagate = False
 # run this part
 # -------------
 
+
 @suppress_warning("invalid character '*' found in formula")
 def run(
     model_path: str,
@@ -50,6 +51,7 @@ def run(
     pc_based_on: Literal["id"] = "id",
     test_aa_auxotrophies: bool = True,
     pathway: bool = True,
+    generate_frog: bool = False,
 ):
     """SPECIMEN Step 5: Analyse the generated model.
 
@@ -76,6 +78,9 @@ def run(
         - pathway (bool, optional):
             Optional to enable KEGG pathway analysis.
             Defaults to True.
+        - generate_frog (bool, optional):
+            Optional to enable FROG report generation.
+            Defaults to False.
     """
 
     total_time_s = time.time()
@@ -93,7 +98,7 @@ def run(
         genlogger.info(f'Creating new directory {Path(dir,"05_analysis")}')
     except FileExistsError:
         genlogger.info("Given directory already has required structure.")
-        
+
     # set path for logging file
     Path(dir, "05_analysis", "analysis.log").unlink(missing_ok=True)
     handler = logging.handlers.RotatingFileHandler(
@@ -111,7 +116,7 @@ def run(
         )
     )
     logger.addHandler(handler)
-    
+
     # redirect cobrapy logging
     cobralogger = logging.getLogger("cobra")
     cobralogger.addHandler(handler)
@@ -136,18 +141,17 @@ def run(
 
     statistics_report = SpecimenModelInfoReport(model)
     statistics_report.save(Path(dir, "05_analysis"))
-    
+
     # ------
     # memote
     # ------
-    
+
     logger.info("\n# ------\n# memote\n# ------")
-    
+
     run_memote(
         model,
         "html",
         save_res=Path(dir, "05_analysis", "final_memote.html"),
-        
     )
 
     # -----------------
@@ -199,6 +203,31 @@ def run(
                 model, media_list[0], media_list[1], namespace
             )
             auxo_report.save(Path(dir, "05_analysis"))
+
+    # -----------
+    # FROG report
+    # -----------
+
+    if generate_frog:
+        logger.info("\n# -----------\n# FROG report\n# -----------")
+        try:
+            import fbc_curation
+
+            frog_out_dir = Path(dir, "05_analysis", "FROG_report")
+            frog_out_dir.mkdir(parents=True, exist_ok=True)
+
+            genlogger.info(f"Generating FROG report in {frog_out_dir}...")
+            # Generate the report based on the SBML model file
+            fbc_curation.run_frog(str(model_path), str(frog_out_dir))
+            genlogger.info("FROG report successfully generated.")
+
+        except ImportError:
+            logger.error(
+                "The 'fbc_curation' package is not installed. Cannot generate FROG report. "
+                "Please install it using 'pip install fbc-curation'."
+            )
+        except Exception as e:
+            logger.error(f"FROG report generation failed: {e}")
 
     total_time_e = time.time()
     logger.info(f"total runtime: {total_time_e-total_time_s}")

--- a/src/specimen/hqtb/core/analysis.py
+++ b/src/specimen/hqtb/core/analysis.py
@@ -226,8 +226,8 @@ def run(
                 "The 'fbc_curation' package is not installed. Cannot generate FROG report. "
                 "Please install it using 'pip install fbc-curation'."
             )
-        except Exception as e:
-            logger.error(f"FROG report generation failed: {e}")
+        except Exception:
+            logger.exception("FROG report generation failed")
 
     total_time_e = time.time()
     logger.info(f"total runtime: {total_time_e-total_time_s}")

--- a/src/specimen/hqtb/core/analysis.py
+++ b/src/specimen/hqtb/core/analysis.py
@@ -216,10 +216,10 @@ def run(
             frog_out_dir = Path(dir, "05_analysis", "FROG_report")
             frog_out_dir.mkdir(parents=True, exist_ok=True)
 
-            genlogger.info(f"Generating FROG report in {frog_out_dir}...")
+            logger.info(f"Generating FROG report in {frog_out_dir}...")
             # Generate the report based on the SBML model file
             fbc_curation.run_frog(str(model_path), str(frog_out_dir))
-            genlogger.info("FROG report successfully generated.")
+            logger.info("FROG report successfully generated.")
 
         except ImportError:
             logger.error(

--- a/src/specimen/hqtb/workflow.py
+++ b/src/specimen/hqtb/workflow.py
@@ -1,5 +1,4 @@
-"""Functions to run the workflow to create a GEM based on a high-quality template model.
-"""
+"""Functions to run the workflow to create a GEM based on a high-quality template model."""
 
 __author__ = "Carolin Brune"
 
@@ -30,9 +29,10 @@ from .. import util
 # functions
 ################################################################################
 
-# since * can be allowed by gapfiller and will be checked in validation, 
+
+# since * can be allowed by gapfiller and will be checked in validation,
 # separate report is suppressed here
-@suppress_warning("invalid character '*' found in formula") 
+@suppress_warning("invalid character '*' found in formula")
 def run(config_file: str = "test_config.yaml"):
     """Run the complete workflow for creating a strain-specific model.
 
@@ -148,14 +148,21 @@ def run(config_file: str = "test_config.yaml"):
 
             # step 3.1: extension
             # ...................
-            
+
             # set a GenBank format FASTA for the extension step (needed for the GapFiller)
-            if config["parameters"]["refinement_cleanup"]["GeneGapFiller parameters"]["fasta"]:
-                fasta_path = config["parameters"]["refinement_cleanup"]["GeneGapFiller parameters"]["fasta"]
+            if config["parameters"]["refinement_cleanup"]["GeneGapFiller parameters"][
+                "fasta"
+            ]:
+                fasta_path = config["parameters"]["refinement_cleanup"][
+                    "GeneGapFiller parameters"
+                ]["fasta"]
             else:
-                fasta_path = mimic_genbank(config["subject"]["annotated_genome"], config["subject"]["gff"],
-                                       str(Path(config["general"]["dir"])))
-            
+                fasta_path = mimic_genbank(
+                    config["subject"]["annotated_genome"],
+                    config["subject"]["gff"],
+                    str(Path(config["general"]["dir"])),
+                )
+
             core.refinement.extend(
                 draft=Path(
                     config["general"]["dir"],
@@ -163,7 +170,7 @@ def run(config_file: str = "test_config.yaml"):
                     modelname + "_draft.xml",
                 ),
                 gff=config["subject"]["gff"],
-                fasta=fasta_path, 
+                fasta=fasta_path,
                 db=config["data"]["diamond"],
                 dir=Path(config["general"]["dir"], "03_refinement"),
                 ncbi_mapping=config["data"]["ncbi_map"],
@@ -335,8 +342,8 @@ def run(config_file: str = "test_config.yaml"):
                     "step4-smoothing",
                     modelname + "_smooth.xml",
                 ),
-                tests=config["parameters"]["validation"]["tests"], 
-                run_all=config["parameters"]["validation"]["run_all"], 
+                tests=config["parameters"]["validation"]["tests"],
+                run_all=config["parameters"]["validation"]["run_all"],
             )
 
     # step 5: analysis
@@ -362,6 +369,7 @@ def run(config_file: str = "test_config.yaml"):
                     "test_aa_auxotrophies"
                 ],
                 pathway=config["parameters"]["analysis"]["pathway"],
+                generate_frog=config["parameters"]["analysis"].get("frog", False),
             )
 
 


### PR DESCRIPTION
### Description
This PR addresses Issue #21 by adding an optional step to generate a FROG (Flux balance constraint Report Objective Generation) report at the end of the analysis pipeline[cite: 11]. 

### Key Changes
*   **Configurations:** Added the `frog: False` parameter to the `hqtb` YAML configuration files (default, advanced, and basic) under the `analysis` step.
*   **Core Logic:** Updated the `run` function in `src/specimen/hqtb/core/analysis.py` to accept the `generate_frog` boolean.
*   **FROG Generation:** Integrated the `fbc_curation.run_frog` function. It creates a dedicated `FROG_report` directory within the analysis output folder and saves the report there.
*   **Safe Import:** Wrapped the `fbc_curation` import in a `try-except` block so that if a user hasn't installed the package, it gracefully logs an error and skips the step without crashing the entire workflow.
*   **Documentation:** Removed the "future update" placeholder for FROG in the `about-pipeline.rst` documentation.

### Testing
*   Verified that the workflow continues without errors when `fbc_curation` is not installed (falls back to logging an error).