### PR TITLE
Add GitHub community and contribution templates

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -16,19 +16,19 @@ diverse, inclusive, and healthy community.
 
 Examples of behaviour that contributes to a positive environment include:
 
-- demonstrating empathy and kindness toward other people;
-- being respectful of differing opinions, viewpoints, and experiences;
-- giving and gracefully accepting constructive feedback;
-- accepting responsibility and apologising to those affected by mistakes;
-- focusing on what is best for the overall community.
+- Demonstrating empathy and kindness toward other people;
+- Being respectful of differing opinions, viewpoints, and experiences;
+- Giving and gracefully accepting constructive feedback;
+- Accepting responsibility and apologising to those affected by mistakes;
+- Focusing on what is best for the overall community.
 
 Examples of unacceptable behaviour include:
 
-- sexualised language or imagery, and sexual attention or advances of any kind;
-- trolling, insulting or derogatory comments, and personal or political attacks;
-- public or private harassment;
-- publishing others' private information without explicit permission;
-- other conduct which could reasonably be considered inappropriate in a
+- Sexualised language or imagery, and sexual attention or advances of any kind;
+- Trolling, insulting or derogatory comments, and personal or political attacks;
+- Public or private harassment;
+- Publishing others' private information without explicit permission;
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting.
 
 ## Enforcement Responsibilities

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,65 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in the
+`SPECIMEN` community a harassment-free experience for everyone, regardless of
+age, body size, visible or invisible disability, ethnicity, sex characteristics,
+gender identity and expression, level of experience, education, socio-economic
+status, nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behaviour that contributes to a positive environment include:
+
+- demonstrating empathy and kindness toward other people;
+- being respectful of differing opinions, viewpoints, and experiences;
+- giving and gracefully accepting constructive feedback;
+- accepting responsibility and apologising to those affected by mistakes;
+- focusing on what is best for the overall community.
+
+Examples of unacceptable behaviour include:
+
+- sexualised language or imagery, and sexual attention or advances of any kind;
+- trolling, insulting or derogatory comments, and personal or political attacks;
+- public or private harassment;
+- publishing others' private information without explicit permission;
+- other conduct which could reasonably be considered inappropriate in a
+  professional setting.
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing standards of
+acceptable behaviour. They may remove, edit, or reject comments, commits, code,
+wiki edits, issues, pull requests, and other contributions that are not aligned
+with this Code of Conduct.
+
+Maintainers may also temporarily or permanently ban any contributor for
+behaviour they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within project spaces and also applies when an
+individual is officially representing the project in public spaces. Examples of
+representing the project include using an official project email address,
+posting through an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be
+reported to the project maintainers listed in the repository metadata or through
+the repository's GitHub issue and discussion channels when appropriate.
+
+All complaints will be reviewed and investigated promptly and fairly. Maintainers
+are obligated to respect the privacy and security of the reporter of any
+incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1,
+available at https://www.contributor-covenant.org/version/2/1/code_of_conduct/.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -55,13 +55,13 @@ Feature requests should describe the workflow problem first, then the proposed i
 
 ## Development workflow
 
-1. Create a feature branch from the active development branch.
+1. Create a feature branch from the active development branch `dev`.
 2. Install SPECIMEN in editable mode with the dependencies needed for the workflow you are changing.
 3. Make a focused change to one workflow, configuration area, documentation area, or external-tool interface at a time.
 4. Update or add configuration examples for any new option.
 5. Run the smallest relevant checks while developing, then validate at least one complete affected pipeline run before opening a pull request.
-6. Update documentation, example notebooks, and diagrams when behavior visible to users changes.
-7. Open a pull request with clear validation notes and any known limitations.
+6. Update documentation, example notebooks, and diagrams when behaviour visible to users changes.
+7. Open a pull request targeting the `dev` branch with clear validation notes and any known limitations.
 
 Avoid changing defaults or configuration keys without a compatibility plan. Existing workflows and example configurations should continue to run unless the pull request explicitly documents a breaking change.
 
@@ -88,7 +88,7 @@ When adding a workflow step or pipeline module:
 - Document how it is enabled, disabled, or configured.
 - Keep file and directory naming deterministic.
 - Validate that the step can run as part of a complete pipeline, not only in isolation.
-- Include clear behavior for missing optional inputs, failed external commands, and empty intermediate results.
+- Include clear behaviour for missing optional inputs, failed external commands, and empty intermediate results.
 - Explain how the step interacts with existing CMPB, HQTB, or future workflow stages.
 - Add or update example input/output when the step changes user-visible artifacts.
 
@@ -97,7 +97,7 @@ When adding a workflow step or pipeline module:
 - Follow the existing Python style and formatting used in the repository.
 - Keep workflow code readable and explicit about data paths, generated files, and external commands.
 - Use type hints and reStructuredText docstrings for public functions.
-- Prefer configuration-driven behavior over hard-coded local paths.
+- Prefer configuration-driven behaviour over hard-coded local paths.
 - Keep default configuration files runnable for documented workflows.
 - Document new configuration keys, allowed values, defaults, and compatibility notes.
 - Update Sphinx pages and HowTo notebooks when the user-facing workflow changes.
@@ -119,7 +119,7 @@ Please include this information in the relevant workflow documentation and menti
 
 ## Testing and validation
 
-Validation should match the risk of the change. For workflow changes, maintainers need evidence that complete pipeline behavior still works.
+Validation should match the risk of the change. For workflow changes, maintainers need evidence that complete pipeline behaviour still works.
 
 Useful validation includes:
 
@@ -128,7 +128,7 @@ Useful validation includes:
 - Comparing key output files, generated reports, and logs against expected results
 - Checking that existing configuration templates still load and remain backward compatible
 - Building or previewing affected Sphinx documentation
-- Testing Docker behavior when the change affects installation, paths, or external tools
+- Testing Docker behaviour when the change affects installation, paths, or external tools
 
 If a full run is too expensive, document the reason and provide the strongest smaller validation you could run.
 
@@ -140,7 +140,7 @@ Before requesting review, please confirm:
 - [ ] Existing workflows and configuration templates are not broken unexpectedly.
 - [ ] New or changed configuration keys are documented.
 - [ ] External dependencies, versions, and computational requirements are documented.
-- [ ] Example input/output or notebooks are updated when user-facing behavior changes.
+- [ ] Example input/output or notebooks are updated when user-facing behaviour changes.
 - [ ] Pipeline diagrams are updated when workflow structure changes.
 - [ ] A complete affected pipeline run was tested, or a limitation is explained.
 - [ ] Logs, generated reports, or other validation evidence are summarized in the pull request.
@@ -156,7 +156,7 @@ Maintainers will review contributions for:
 - Robust handling of external tools and generated files
 - Documentation completeness
 - Clarity of validation evidence
-- Impact on existing CMPB, HQTB, and future workflow behavior
+- Impact on existing CMPB, HQTB, and future workflow behaviour
 
 Review may request smaller pull requests, more complete validation, additional documentation, or compatibility adjustments before merge.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,171 @@
+# SPECIMEN CONTRIBUTING.md
+
+## Welcome
+
+Thank you for helping improve SPECIMEN. SPECIMEN is a collection of workflows for automated, standardized curation of genome-scale metabolic models. Contributions are most useful when they keep complete workflows reproducible, configurable, and documented for other modelling projects.
+
+This guide focuses on the kinds of changes contributors usually make in SPECIMEN:
+
+- Workflows and pipeline modules
+- Configuration templates and default parameters
+- Documentation and pipeline diagrams
+- Example datasets and example input/output
+- Interfaces to external tools
+- Validation of complete pipeline runs
+
+## Ways to contribute
+
+You can contribute by:
+
+- Reporting reproducible bugs in CMPB, HQTB, or future workflows
+- Suggesting new workflow steps or refinements
+- Improving configuration templates in `src/specimen/data/config/`
+- Updating Sphinx documentation in `docs/source/`
+- Adding or improving example notebooks in `HowTo/`
+- Documenting required software, versions, and computational requirements
+- Improving interfaces to external tools such as refineGEMs, CarveMe, DIAMOND, EntrezDirect, or ModelPolisher
+- Adding example input/output that helps others validate a workflow change
+
+## Reporting bugs
+
+Please open a bug report with enough information for maintainers to reproduce the problem. Include:
+
+- The workflow and command you ran, for example CMPB or HQTB through `specimen`
+- The configuration file used, with private paths or accessions removed if needed
+- Input data type and a minimal example, when possible
+- SPECIMEN version or commit, Python version, and operating system
+- External tool versions and installation method, especially Docker, pip editable install, or system packages
+- The expected output and the actual output
+- Logs, tracebacks, and generated reports
+- Whether the same input worked with an earlier SPECIMEN version or configuration template
+
+For workflow bugs, please say whether the failure happens before, during, or after a complete pipeline run. Partial-step failures are useful, but complete-run context helps identify configuration compatibility and downstream effects.
+
+## Suggesting new features
+
+Feature requests should describe the workflow problem first, then the proposed implementation. Helpful requests include:
+
+- The modelling or curation task the feature supports
+- The workflow step where it belongs
+- Required input files and expected output files
+- New external software, databases, web services, or credentials
+- Expected runtime, memory, storage, or network requirements
+- Compatibility expectations for existing configuration templates
+- Documentation, diagram, and example-data updates needed to make the feature usable
+
+## Development workflow
+
+1. Create a feature branch from the active development branch.
+2. Install SPECIMEN in editable mode with the dependencies needed for the workflow you are changing.
+3. Make a focused change to one workflow, configuration area, documentation area, or external-tool interface at a time.
+4. Update or add configuration examples for any new option.
+5. Run the smallest relevant checks while developing, then validate at least one complete affected pipeline run before opening a pull request.
+6. Update documentation, example notebooks, and diagrams when behavior visible to users changes.
+7. Open a pull request with clear validation notes and any known limitations.
+
+Avoid changing defaults or configuration keys without a compatibility plan. Existing workflows and example configurations should continue to run unless the pull request explicitly documents a breaking change.
+
+## Expected directory structure
+
+Use the existing project layout when adding or changing files:
+
+- `src/specimen/cmpb/` contains CMPB workflow code.
+- `src/specimen/hqtb/` contains HQTB workflow code.
+- `src/specimen/hqtb/core/` contains HQTB pipeline modules.
+- `src/specimen/data/config/` contains packaged configuration templates.
+- `docs/source/` contains Sphinx documentation.
+- `docs/source/images/` contains pipeline diagrams and documentation images.
+- `HowTo/` contains example notebooks.
+- `dev/` contains developer notes, experiments, and local helper material.
+
+If a new workflow is added, keep its command-line interface, configuration templates, documentation pages, and diagrams discoverable from the same top-level documentation structure as the existing workflows.
+
+## Adding new workflow steps
+
+When adding a workflow step or pipeline module:
+
+- Define its inputs, outputs, and side effects.
+- Document how it is enabled, disabled, or configured.
+- Keep file and directory naming deterministic.
+- Validate that the step can run as part of a complete pipeline, not only in isolation.
+- Include clear behavior for missing optional inputs, failed external commands, and empty intermediate results.
+- Explain how the step interacts with existing CMPB, HQTB, or future workflow stages.
+- Add or update example input/output when the step changes user-visible artifacts.
+
+## Coding and documentation standards
+
+- Follow the existing Python style and formatting used in the repository.
+- Keep workflow code readable and explicit about data paths, generated files, and external commands.
+- Use type hints and reStructuredText docstrings for public functions.
+- Prefer configuration-driven behavior over hard-coded local paths.
+- Keep default configuration files runnable for documented workflows.
+- Document new configuration keys, allowed values, defaults, and compatibility notes.
+- Update Sphinx pages and HowTo notebooks when the user-facing workflow changes.
+- Update pipeline diagrams when step order, data flow, or major outputs change.
+
+## Documenting required software
+
+Changes that add or modify external dependencies should document:
+
+- Software name and purpose
+- Minimum tested version
+- Installation source or reference documentation
+- Required databases, indexes, credentials, or network access
+- Expected command-line availability
+- Runtime, memory, disk, and temporary-file requirements
+- Docker-specific notes, if the dependency behaves differently in containers
+
+Please include this information in the relevant workflow documentation and mention it in the pull request.
+
+## Testing and validation
+
+Validation should match the risk of the change. For workflow changes, maintainers need evidence that complete pipeline behavior still works.
+
+Useful validation includes:
+
+- Running the affected workflow from the command line with a documented configuration file
+- Running a minimal example dataset through the full pipeline
+- Comparing key output files, generated reports, and logs against expected results
+- Checking that existing configuration templates still load and remain backward compatible
+- Building or previewing affected Sphinx documentation
+- Testing Docker behavior when the change affects installation, paths, or external tools
+
+If a full run is too expensive, document the reason and provide the strongest smaller validation you could run.
+
+## Pull request checklist
+
+Before requesting review, please confirm:
+
+- [ ] The change has a focused scope and a clear motivation.
+- [ ] Existing workflows and configuration templates are not broken unexpectedly.
+- [ ] New or changed configuration keys are documented.
+- [ ] External dependencies, versions, and computational requirements are documented.
+- [ ] Example input/output or notebooks are updated when user-facing behavior changes.
+- [ ] Pipeline diagrams are updated when workflow structure changes.
+- [ ] A complete affected pipeline run was tested, or a limitation is explained.
+- [ ] Logs, generated reports, or other validation evidence are summarized in the pull request.
+- [ ] The documentation builds or affected documentation files were reviewed.
+- [ ] Breaking changes are called out explicitly.
+
+## Review process
+
+Maintainers will review contributions for:
+
+- Reproducibility of the workflow or example
+- Compatibility with existing configuration templates
+- Robust handling of external tools and generated files
+- Documentation completeness
+- Clarity of validation evidence
+- Impact on existing CMPB, HQTB, and future workflow behavior
+
+Review may request smaller pull requests, more complete validation, additional documentation, or compatibility adjustments before merge.
+
+## Getting help
+
+If you are unsure where a change belongs, open an issue before starting a large implementation. For questions, include the workflow, configuration file, expected inputs and outputs, external tools involved, and what you have already tried.
+
+## Citation
+
+If you use SPECIMEN in research, please cite the project using the citation information in the repository and the Zenodo DOI badge shown in the README:
+
+https://doi.org/10.5281/zenodo.12723500

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -19,9 +19,16 @@ body:
         - Documentation
         - Example notebooks or datasets
         - External tool interface
-        - Other
+        - Other (Please specify below)
     validations:
       required: true
+  - type: input
+    id: workflow-other-category
+    attributes:
+      label: If you selected "Other", please specify
+      placeholder: Describe what your suggestion affects
+    validations:
+      required: false
   - type: textarea
     id: summary
     attributes:
@@ -45,7 +52,7 @@ body:
     id: expected
     attributes:
       label: Expected result
-      description: What output, report, or workflow behavior did you expect?
+      description: What output, report, or workflow behaviour did you expect?
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,95 @@
+name: Bug report
+description: Report a reproducible SPECIMEN workflow, configuration, documentation, or external-tool problem.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a SPECIMEN issue. Please include enough workflow and environment detail for maintainers to reproduce the problem.
+  - type: dropdown
+    id: workflow
+    attributes:
+      label: Affected workflow or area
+      options:
+        - CMPB
+        - HQTB
+        - PGAB
+        - Configuration templates
+        - Documentation
+        - Example notebooks or datasets
+        - External tool interface
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the problem and where the workflow failed.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Include the command, configuration file, and minimal input data when possible.
+      placeholder: |
+        1. Installed with ...
+        2. Ran ...
+        3. Used configuration ...
+        4. Observed ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected result
+      description: What output, report, or workflow behavior did you expect?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual result, logs, or traceback
+      description: Paste relevant logs, generated reports, or tracebacks.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: config
+    attributes:
+      label: Configuration details
+      description: Paste relevant configuration sections. Remove private paths, tokens, or unpublished data.
+      render: yaml
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment and external tools
+      description: Include SPECIMEN commit/version, Python version, OS, installation method, and external tool versions.
+      placeholder: |
+        SPECIMEN:
+        Python:
+        OS:
+        Install method:
+        refineGEMs:
+        CarveMe:
+        DIAMOND:
+        EntrezDirect:
+        Docker:
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation context
+      description: Did this fail in a complete pipeline run, a single step, or after changing a configuration template?
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checks
+      options:
+        - label: I searched existing issues for a similar report.
+          required: true
+        - label: I removed private data, credentials, and unpublished sensitive paths from this report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -19,9 +19,16 @@ body:
         - Example dataset or notebook
         - Pipeline diagram
         - External tool interface
-        - Other
+        - Other (Please specify below)
     validations:
       required: true
+  - type: input
+    id: workflow-other-category
+    attributes:
+      label: If you selected "Other", please specify
+      placeholder: Describe what your suggestion affects
+    validations:
+      required: false
   - type: textarea
     id: problem
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,63 @@
+name: Feature request
+description: Suggest a SPECIMEN workflow, configuration, documentation, example, or external-tool improvement.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        SPECIMEN feature requests are easiest to evaluate when they describe the workflow need, expected inputs and outputs, dependencies, and validation plan.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Contribution area
+      options:
+        - New workflow step
+        - Existing workflow change
+        - Configuration template
+        - Documentation
+        - Example dataset or notebook
+        - Pipeline diagram
+        - External tool interface
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Workflow problem or use case
+      description: What modelling, curation, validation, or documentation problem should this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the new behavior, workflow step, configuration, or documentation change.
+    validations:
+      required: true
+  - type: textarea
+    id: inputs_outputs
+    attributes:
+      label: Inputs and outputs
+      description: List required input files, generated output files, reports, and example data that should be added or updated.
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: External dependencies and computational requirements
+      description: List required software, databases, versions, network access, runtime, memory, disk, or Docker considerations.
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Configuration and workflow compatibility
+      description: Explain how this should interact with existing configuration templates and workflows.
+  - type: textarea
+    id: validation
+    attributes:
+      label: Suggested validation
+      description: How could maintainers test the feature in a complete or minimal pipeline run?
+  - type: textarea
+    id: docs
+    attributes:
+      label: Documentation updates
+      description: Note any Sphinx pages, HowTo notebooks, diagrams, or examples that should be updated.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,12 +1,12 @@
 name: Feature request
-description: Suggest a SPECIMEN workflow, configuration, documentation, example, or external-tool improvement.
+description: Suggest a SPECIMEN workflow modification, configuration, documentation, example, or external-tool improvement.
 title: "[Feature]: "
 labels: ["enhancement"]
 body:
   - type: markdown
     attributes:
       value: |
-        SPECIMEN feature requests are easiest to evaluate when they describe the workflow need, expected inputs and outputs, dependencies, and validation plan.
+        SPECIMEN feature requests are easiest to evaluate when they describe the workflow modification need, expected inputs and outputs, dependencies, and validation plan.
   - type: dropdown
     id: area
     attributes:
@@ -33,7 +33,7 @@ body:
     id: proposal
     attributes:
       label: Proposed solution
-      description: Describe the new behavior, workflow step, configuration, or documentation change.
+      description: Describe the new behaviour, workflow step, configuration, or documentation change.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/workflow_suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/workflow_suggestion.yml
@@ -1,0 +1,74 @@
+name: Workflow suggestion
+description: Propose a new SPECIMEN workflow, workflow step, or change to pipeline structure.
+title: "[Workflow]: "
+labels: ["workflow", "enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for suggestions that affect SPECIMEN pipeline structure, workflow order, configuration behavior, or complete-run validation.
+  - type: dropdown
+    id: workflow
+    attributes:
+      label: Target workflow
+      options:
+        - CMPB
+        - HQTB
+        - PGAB
+        - New workflow
+        - Cross-workflow change
+        - Not sure
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: What modelling, curation, reproducibility, or usability problem should this workflow change solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposed_flow
+    attributes:
+      label: Proposed workflow structure
+      description: Describe the proposed steps, their order, and how data should move between them.
+      placeholder: |
+        1. Input preparation:
+        2. Draft model generation:
+        3. Refinement:
+        4. Validation:
+        5. Reports/output:
+    validations:
+      required: true
+  - type: textarea
+    id: inputs_outputs
+    attributes:
+      label: Inputs, outputs, and example data
+      description: List required inputs, generated outputs, reports, and example datasets or files that would help validate the workflow.
+  - type: textarea
+    id: configuration
+    attributes:
+      label: Configuration impact
+      description: Describe new or changed configuration keys, defaults, compatibility concerns, and migration needs.
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: External tools and computational requirements
+      description: List required software, databases, versions, network access, runtime, memory, disk, or Docker considerations.
+  - type: textarea
+    id: validation
+    attributes:
+      label: Complete-run validation plan
+      description: How should maintainers test that this workflow works end to end and does not break existing workflows?
+    validations:
+      required: true
+  - type: textarea
+    id: docs
+    attributes:
+      label: Documentation, diagrams, and examples
+      description: Which Sphinx pages, HowTo notebooks, pipeline diagrams, or example input/output should be added or updated?
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Are there simpler workflow changes, existing tools, or current SPECIMEN steps that could solve this instead?

--- a/.github/ISSUE_TEMPLATE/workflow_suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/workflow_suggestion.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Use this form for suggestions that affect SPECIMEN pipeline structure, workflow order, configuration behavior, or complete-run validation.
+        Use this form for suggestions that affect SPECIMEN workflows, workflow steps, pipeline structure, configuration behaviour, or complete-run validation.
   - type: dropdown
     id: workflow
     attributes:
@@ -17,9 +17,16 @@ body:
         - PGAB
         - New workflow
         - Cross-workflow change
-        - Not sure
+        - Other (Please specify below)
     validations:
       required: true
+  - type: input
+    id: workflow-other-category
+    attributes:
+      label: If you selected "Other", please specify
+      placeholder: Describe what your suggestion affects
+    validations:
+      required: false
   - type: textarea
     id: motivation
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,7 +28,7 @@ Describe what you ran and summarize the result. Include complete pipeline runs w
 - [ ] Minimal example dataset run
 - [ ] Existing configuration templates checked
 - [ ] Documentation build or preview checked
-- [ ] Docker behavior checked, if relevant
+- [ ] Docker behaviour checked, if relevant
 - [ ] External tool versions checked, if relevant
 
 Validation notes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,52 @@
+# Pull request
+
+## Summary
+
+- 
+
+## Contribution area
+
+- [ ] Workflow or pipeline module
+- [ ] Configuration template
+- [ ] Documentation
+- [ ] Example dataset or notebook
+- [ ] Pipeline diagram
+- [ ] External tool interface
+- [ ] Other
+
+## Workflow impact
+
+Affected workflows, steps, configuration files, external tools, and generated outputs:
+
+- 
+
+## Validation
+
+Describe what you ran and summarize the result. Include complete pipeline runs when possible.
+
+- [ ] Complete affected pipeline run
+- [ ] Minimal example dataset run
+- [ ] Existing configuration templates checked
+- [ ] Documentation build or preview checked
+- [ ] Docker behavior checked, if relevant
+- [ ] External tool versions checked, if relevant
+
+Validation notes:
+
+```text
+
+```
+
+## Documentation and examples
+
+- [ ] New or changed configuration keys are documented.
+- [ ] Required software and computational requirements are documented.
+- [ ] Example input/output or notebooks are updated, if relevant.
+- [ ] Pipeline diagrams are updated, if relevant.
+- [ ] Breaking changes are clearly described.
+
+## Reviewer notes
+
+Known limitations, expensive validation that was not run, or follow-up work:
+
+- 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Currently avaible workflow:
         - [pypi After install via pip](#pypi-after-install-via-pip)
         - [docker After install via Docker](#docker-after-install-via-docker)
     - [Documentation](#documentation)
+    - [Contributing](#contributing)
     - [Repositories using SPECIMEN](#repositories-using-specimen)
 
 <!-- /TOC -->
@@ -108,6 +109,11 @@ For example, to run the CMPB pipeline, use:
 > 🚧 The documentation is currently under heavy-rework!
 
 For more information about the available pipelines, the code or for troubleshooting, please refer to the documentation of the tool [here](https://specimen.readthedocs.io/en/latest/).
+
+## Contributing
+
+Contributions are welcome! Please read our [Contributing Guide](.github/CONTRIBUTING.md) before opening an issue or submitting a pull request.
+Please also follow our [Code of Conduct](.github/CODE_OF_CONDUCT.md).
 
 ## Repositories using SPECIMEN
 - draeger-lab/Cacnes - `private`


### PR DESCRIPTION
Introduce repository community health docs and contribution scaffolding under .github, including a Code of Conduct, a SPECIMEN-focused CONTRIBUTING guide, issue templates for bugs/features/workflow suggestions, and a pull request template. These additions standardise how contributors report issues and propose changes, with emphasis on workflow reproducibility, configuration compatibility, and validation evidence.

Assisted by: Codex