### PR TITLE
feat: Add debug switch for intermediate growth tests in CMPB

### DIFF
--- a/src/specimen/cmpb/workflow.py
+++ b/src/specimen/cmpb/workflow.py
@@ -26,7 +26,12 @@ from refinegems.classes.reports import ModelInfoReport, SBOTermReport
 from refinegems.utility.util import test_biomass_presence
 from refinegems.curation.biomass import check_normalise_biomass
 from refinegems.curation.charges import correct_charges_modelseed
-from refinegems.curation.curate import resolve_duplicates, check_direction, polish_model, prune_mass_unbalanced_reacs
+from refinegems.curation.curate import (
+    resolve_duplicates,
+    check_direction,
+    polish_model,
+    prune_mass_unbalanced_reacs,
+)
 from refinegems.curation.miriam import change_all_qualifiers, polish_annotations
 from refinegems.classes.gapfill import KEGGapFiller, BioCycGapFiller, GeneGapFiller
 from refinegems.curation.pathways import set_kegg_pathways, kegg_pathway_analysis
@@ -39,9 +44,13 @@ from refinegems.utility.connections import (
     perform_mcc,
     adjust_BOF,
     run_SBOannotator,
-    run_ModelPolisher
+    run_ModelPolisher,
 )
-from refinegems.utility.io import load_model, convert_cobra_to_libsbml, write_model_to_file
+from refinegems.utility.io import (
+    load_model,
+    convert_cobra_to_libsbml,
+    write_model_to_file,
+)
 from refinegems.developement.decorators import implement
 from refinegems.classes import egcs
 
@@ -57,12 +66,13 @@ logger = logging.getLogger(__name__)
 # functions
 ################################################################################
 
+
 # @TODO Add debug switches to test growth on every step (Maybe also on full medium?) -> Maybe as entry point?
 # @ASK Provide the draft model directly from CarveMe only in debug mode or always? -> Is always provided already.
 # dev notes:
 #   in the run function: current_model means the cobrapy model,
 #   while current_libmodel means the libsbml model
-def run(configpath: Union[str, None] = None):
+def run(configpath: Union[str, None] = None, debug_growth: bool = False):
     """Run the CarveMe-ModelPolisher-based (CMPB) workflow.
 
     Args:
@@ -70,14 +80,17 @@ def run(configpath: Union[str, None] = None):
             The Path to a configuration file. If none given, prompts the user to enter the needed
             information step by step.
             Defaults to None.
+        - debug_growth (bool, optional):
+            Debug switch to test and report growth at every intermediate step.
+            Defaults to False.
     """
 
     def between_save(
         model: Union[Model, libModel],
         model_dir: Union[None, str] = None,
         label: Union[None, str] = None,
-        only_modelpath: Union[None, str] = None
-    ): 
+        only_modelpath: Union[None, str] = None,
+    ):
         """Helper function to save the model in between the different steps of the workflow
 
         Args:
@@ -94,9 +107,7 @@ def run(configpath: Union[str, None] = None):
         """
         name = model.id if isinstance(model, Model) else model.getId()
         if not only_modelpath:
-            write_model_to_file(
-                model, str(Path(model_dir, f"{name}_{label}.xml"))
-            )
+            write_model_to_file(model, str(Path(model_dir, f"{name}_{label}.xml")))
         else:
             write_model_to_file(model, str(only_modelpath))
 
@@ -112,7 +123,7 @@ def run(configpath: Union[str, None] = None):
             - step (str):
                 Descriptive string for the current step of the pipeline (important for saving the output).
         """
- 
+
         # try to set objective to growth
         growth_func_list = test_biomass_presence(model)
         if growth_func_list:
@@ -134,7 +145,7 @@ def run(configpath: Union[str, None] = None):
                 logger.warning(
                     f"Given directory {growth_dir} already exists. High possibility of files being overwritten."
                 )
-            
+
             growth_report.save(
                 growth_dir,
                 color_palette=config["general"]["colours"],
@@ -177,7 +188,7 @@ def run(configpath: Union[str, None] = None):
                 logger.warning(
                     f"Given directory {stats_dir} already exists. High possibility of files being overwritten."
                 )
-                
+
             report.save(
                 Path(stats_dir),
                 color_palette=config["general"]["colours"],
@@ -217,9 +228,9 @@ def run(configpath: Union[str, None] = None):
 
     # Set up directory structure names
     PARENT_DIR = config["general"]["dir"]
-    CMPB_OUT_DIR = Path(PARENT_DIR, 'cmpb_out')
-    MODEL_DIR = Path(CMPB_OUT_DIR, 'models')
-    MISC_DIR = Path(CMPB_OUT_DIR, 'misc')
+    CMPB_OUT_DIR = Path(PARENT_DIR, "cmpb_out")
+    MODEL_DIR = Path(CMPB_OUT_DIR, "models")
+    MISC_DIR = Path(CMPB_OUT_DIR, "misc")
 
     # Get cmodel path if only one model should be saved
     only_modelpath = None
@@ -234,7 +245,7 @@ def run(configpath: Union[str, None] = None):
     # ----------
     today = date.today().strftime("%Y%m%d")
     log_file = Path(CMPB_OUT_DIR, "logs", f"specimen_cmpb_{str(today)}.log")
-    log_file.unlink(missing_ok=True) # Remove file in case it already exists
+    log_file.unlink(missing_ok=True)  # Remove file in case it already exists
     handler = logging.handlers.RotatingFileHandler(
         log_file, mode="w", backupCount=10, encoding="utf-8", delay=0
     )
@@ -257,15 +268,17 @@ def run(configpath: Union[str, None] = None):
     rglogger.propagate = False
 
     total_time_s = time.time()
-    
+
     # CarveMe
     #########
     if not config["input"]["modelpath"]:
-        
+
         logger.info("Creating a draft model with CarveMe ...")
         step_start = time.time()
-        
-        out_modelpath = only_modelpath if only_modelpath else Path(MODEL_DIR, modelname+'.xml')
+
+        out_modelpath = (
+            only_modelpath if only_modelpath else Path(MODEL_DIR, modelname + ".xml")
+        )
         if (
             config["carveme"]["gram"] == "grampos"
             or config["carveme"]["gram"] == "gramneg"
@@ -278,7 +291,7 @@ def run(configpath: Union[str, None] = None):
                 f"carve {config['general']['protein_fasta']} --solver scip -o {out_modelpath}"
             )
         config["input"]["modelpath"] = out_modelpath
-        
+
         step_end = time.time()
         logger.info(f"CarveMe\truntime: {step_end-step_start}s\n")
 
@@ -287,10 +300,10 @@ def run(configpath: Union[str, None] = None):
 
     # load & validate compartments of the loaded model
     ##################################################
-    
+
     logger.info("Validating compartments ...")
     step_start = time.time()
-    
+
     # load into libsbml
     current_libmodel = load_model(str(current_modelpath), "libsbml")
 
@@ -301,13 +314,11 @@ def run(configpath: Union[str, None] = None):
         # if not, attempt to fix them
         resolve_compartment_names(current_model)
         # save validated model
-        between_save(
-            current_model, MODEL_DIR, "validated_comps", only_modelpath
-        )
+        between_save(current_model, MODEL_DIR, "validated_comps", only_modelpath)
 
         # Transform model into libmodel for CarveMe correction
-        current_libmodel = convert_cobra_to_libsbml(current_model, 'notes')
-        
+        current_libmodel = convert_cobra_to_libsbml(current_model, "notes")
+
     step_end = time.time()
     logger.info(f"Compartment validation\truntime: {step_end-step_start}s\n")
 
@@ -315,11 +326,13 @@ def run(configpath: Union[str, None] = None):
     ####################
 
     # check, if input is a CarveMe model
-    if ("CarveMe" in current_libmodel.getNotesString()) or ("CarveMe" in current_libmodel.getAnnotationString()):
-        
+    if ("CarveMe" in current_libmodel.getNotesString()) or (
+        "CarveMe" in current_libmodel.getAnnotationString()
+    ):
+
         logger.info("Performing CarveMe correction ...")
         step_start = time.time()
-        
+
         # Set up directory for report output
         current_sub_dir = Path(MISC_DIR, "model_correction")
         try:
@@ -354,14 +367,15 @@ def run(configpath: Union[str, None] = None):
         between_save(
             current_libmodel, MODEL_DIR, "after_CarveMe_correction", only_modelpath
         )
-        
+
         step_end = time.time()
         logger.info(f"CarveMe correction\truntime: {step_end-step_start}s\n")
 
     # growth test
     # -----------
     current_model = _sbml_to_model(current_libmodel.getSBMLDocument())
-    between_growth_test(current_model, config, step="after_draft")
+    if debug_growth:
+        between_growth_test(current_model, config, step="after_draft")
     between_analysis(current_model, config, step="after_draft")
 
     # gapfilling
@@ -370,7 +384,13 @@ def run(configpath: Union[str, None] = None):
     run_gapfill = False
 
     # Set up directory for gapfill output, only if any of the gapfillers are activated
-    if any([config["gapfilling"]["KEGGapFiller"], config["gapfilling"]["BioCycGapFiller"], config["gapfilling"]["GeneGapFiller"]]):
+    if any(
+        [
+            config["gapfilling"]["KEGGapFiller"],
+            config["gapfilling"]["BioCycGapFiller"],
+            config["gapfilling"]["GeneGapFiller"],
+        ]
+    ):
         current_sub_dir = Path(MISC_DIR, "gapfill")
         try:
             Path(current_sub_dir).mkdir(parents=True, exist_ok=False)
@@ -379,13 +399,13 @@ def run(configpath: Union[str, None] = None):
             logger.warning(
                 f"Given directory {current_sub_dir} already exists. High possibility of files being overwritten."
             )
-    
+
     # KEGGapFiller
     if config["gapfilling"]["KEGGapFiller"]:
-        
+
         logger.info("Filling gaps based on KEGG ...")
         step_start = time.time()
-        
+
         if config["general"]["kegg_organism_id"]:
             run_gapfill = True
             # gapfilling with KEGG via KEGG organism ID
@@ -402,7 +422,7 @@ def run(configpath: Union[str, None] = None):
             )
             # save GapFillerReport
             kgf.report(str(current_sub_dir))
-            
+
             # save model
             between_save(
                 current_libmodel, MODEL_DIR, "after_KEGG_gapfill", only_modelpath
@@ -412,16 +432,16 @@ def run(configpath: Union[str, None] = None):
         else:
             mes = f"No KEGG organism ID provided. Gapfilling with KEGG will be skipped."
             raise logger.warning(mes, UserWarning)
-        
+
         step_end = time.time()
         logger.info(f"KEGGapFiller\truntime: {step_end-step_start}s\n")
 
     # BioCycGapFiller
     if config["gapfilling"]["BioCycGapFiller"]:
-        
+
         logger.info("Filling gaps based on BioCyc ...")
         step_start = time.time()
-        
+
         run_gapfill = True
         bcgf = BioCycGapFiller(
             config["gapfilling"]["BioCycGapFiller parameters"]["gene-table"],
@@ -441,22 +461,22 @@ def run(configpath: Union[str, None] = None):
         )
         # save GapFillerReport
         bcgf.report(str(current_sub_dir))
-        
+
         # save model
         between_save(
             current_libmodel, MODEL_DIR, "after_BioCyc_gapfill", only_modelpath
         )
         current_model = _sbml_to_model(current_libmodel.getSBMLDocument())
-        
+
         step_end = time.time()
         logger.info(f"BioCycGapfiller\truntime: {step_end-step_start}s\n")
 
     # GeneGapFiller
     if config["gapfilling"]["GeneGapFiller"]:
-        
+
         logger.info("Filling gaps based on genes ...")
         step_start = time.time()
-        
+
         run_gapfill = True
         ggf = GeneGapFiller()
         ggf.find_missing_genes(
@@ -488,12 +508,10 @@ def run(configpath: Union[str, None] = None):
         )
         # save GapFillerReport
         ggf.report(str(current_sub_dir))
-        
+
         # save model
-        between_save(
-            current_libmodel, MODEL_DIR, "after_Gene_gapfill", only_modelpath
-        )
-        
+        between_save(current_libmodel, MODEL_DIR, "after_Gene_gapfill", only_modelpath)
+
         step_end = time.time()
         logger.info(f"GeneGapFiller\truntime: {step_end-step_start}s\n")
 
@@ -501,7 +519,8 @@ def run(configpath: Union[str, None] = None):
 
     # testing
     if run_gapfill:
-        between_growth_test(current_model, config, step="after_gapfill")
+        if debug_growth:
+            between_growth_test(current_model, config, step="after_gapfill")
         between_analysis(current_model, config, step="after_gapfill")
 
     # model cleanup - part 1
@@ -509,10 +528,10 @@ def run(configpath: Union[str, None] = None):
 
     # duplicates
     # ----------
-    
+
     logger.info("Handling duplicates ...")
     step_start = time.time()
-    
+
     match config["duplicates"]["reactions"]:
         case "remove":
             check_dupl_reac = True
@@ -553,29 +572,30 @@ def run(configpath: Union[str, None] = None):
         remove_unused_meta=config["duplicates"]["remove_unused_metabs"],
         remove_dupl_reac=remove_dupl_reac,
     )
-    
+
     step_end = time.time()
     logger.info(f"Duplicates\truntime: {step_end-step_start}s\n")
 
     # save model
-    between_save(
-        current_model, MODEL_DIR, "after_duplicate_removal", only_modelpath
-    )
+    between_save(current_model, MODEL_DIR, "after_duplicate_removal", only_modelpath)
 
     # in-between testing
-    between_growth_test(current_model, config, step="after_duplicate_removal")
+    if debug_growth:
+        between_growth_test(current_model, config, step="after_duplicate_removal")
     between_analysis(current_model, config, step="after_duplicate_removal")
 
-    current_libmodel = convert_cobra_to_libsbml(current_model, 'notes')
+    current_libmodel = convert_cobra_to_libsbml(current_model, "notes")
 
     # ModelPolisher
     ###############
     if config["modelpolisher"]:
-        logger.warning('ModelPolisher is currently not maintained and might not work as expected. Use at your own risk.')
-        
+        logger.warning(
+            "ModelPolisher is currently not maintained and might not work as expected. Use at your own risk."
+        )
+
         logger.info("Running ModelPolisher ...")
         step_start = time.time()
-        
+
         config_mp = {
             "allow-model-to-be-saved-on-server": config["mp"][
                 "allow-model-to-be-saved-on-server"
@@ -597,7 +617,7 @@ def run(configpath: Union[str, None] = None):
 
         if result:
             # Set up directory for result output
-            current_sub_dir = Path(MISC_DIR, "modelpolisher", "run_" + result['run_id'])
+            current_sub_dir = Path(MISC_DIR, "modelpolisher", "run_" + result["run_id"])
             try:
                 Path(current_sub_dir).mkdir(parents=True, exist_ok=False)
                 print(f"Creating new directory {current_sub_dir}")
@@ -605,8 +625,8 @@ def run(configpath: Union[str, None] = None):
                 logger.warning(
                     f"Given directory {current_sub_dir} already exists. High possibility of files being overwritten."
                 )
-            
-            if len(result['diff']) > 1:
+
+            if len(result["diff"]) > 1:
                 pd.DataFrame(result["diff"]).to_csv(
                     Path(current_sub_dir, "diff_mp.csv"),
                     sep=";",
@@ -614,7 +634,7 @@ def run(configpath: Union[str, None] = None):
                 )
             else:
                 logger.warning(f'{result["diff"]}')
-            
+
             pd.DataFrame(result["pre_validation"]).to_csv(
                 Path(current_sub_dir, "pre_validation.csv"),
                 sep=";",
@@ -635,27 +655,30 @@ def run(configpath: Union[str, None] = None):
             current_model = _sbml_to_model(current_libmodel.getSBMLDocument())
 
             # in-between testing
-            between_growth_test(current_model, config, step="after_ModelPolisher")
+            if debug_growth:
+                between_growth_test(current_model, config, step="after_ModelPolisher")
             between_analysis(current_model, config, step="after_ModelPolisher")
         else:
-            logger.warning('No result was produced with ModelPolisher. This step will be skipped.')
-            
+            logger.warning(
+                "No result was produced with ModelPolisher. This step will be skipped."
+            )
+
         step_end = time.time()
         logger.info(f"ModelPolisher\truntime: {step_end-step_start}s\n")
 
     # Annotations
     #############
 
-    # @BUG/@WARNING: 
+    # @BUG/@WARNING:
     # The correct annotation for pathways gets missing between after the following step and reaction direction.
     # @IDEA Possible solution would be to run polish_annotations & change_all_qualifiers at the end again?
     # KEGGPathwayGroups
     # -----------------
     if config["kegg_pathway_groups"]["add"]:
-        
+
         logger.info("Adding KEGG pathway groups ...")
         step_start = time.time()
-        
+
         missing_list = set_kegg_pathways(
             current_libmodel,
             viaEC=config["kegg_pathway_groups"]["viaEC"],
@@ -676,7 +699,7 @@ def run(configpath: Union[str, None] = None):
         between_save(
             current_libmodel, MODEL_DIR, "added_KeggPathwayGroups", only_modelpath
         )
-        
+
         step_end = time.time()
         logger.info(f"KEGGPathwayGroups\truntime: {step_end-step_start}s\n")
 
@@ -684,19 +707,17 @@ def run(configpath: Union[str, None] = None):
     # ------------
     logger.info("Running SBOannotator ...")
     step_start = time.time()
-    
+
     current_libmodel = run_SBOannotator(current_libmodel)
-    
+
     step_end = time.time()
     logger.info(f"SBOannotator\truntime: {step_end-step_start}s\n")
-    
-    between_save(
-        current_libmodel, MODEL_DIR, "SBOannotated", only_modelpath
-    )
+
+    between_save(current_libmodel, MODEL_DIR, "SBOannotated", only_modelpath)
 
     current_model = _sbml_to_model(current_libmodel.getSBMLDocument())
     between_analysis(current_model, config, step="after_annotation")
-    
+
     # Model cleanup - part 2
     ########################
 
@@ -705,7 +726,7 @@ def run(configpath: Union[str, None] = None):
     if config["reaction_direction"]:
         logger.info("Checking reaction direction with BioCyc ...")
         step_start = time.time()
-        
+
         current_model = check_direction(current_model, config["reaction_direction"])
 
         step_end = time.time()
@@ -715,25 +736,23 @@ def run(configpath: Union[str, None] = None):
     between_save(
         current_model, MODEL_DIR, "after_reac_direction_change", only_modelpath
     )
-    
+
     # MCC
     # ---
     logger.info("Running MCC ...")
     step_start = time.time()
-    
-    current_model = perform_mcc(
-        current_model, Path(MISC_DIR, "mcc"), apply=True
-    )
-    
+
+    current_model = perform_mcc(current_model, Path(MISC_DIR, "mcc"), apply=True)
+
     step_end = time.time()
     logger.info(f"MCC\truntime: {step_end-step_start}s\n")
 
     # find and solve energy generating cycles
     # ---------------------------------------
-    
+
     logger.info("Finding (and resolving) EGCs ...")
     step_start = time.time()
-    
+
     results = None
     match config["EGCs"]["solver"]:
         # greedy solver
@@ -757,25 +776,24 @@ def run(configpath: Union[str, None] = None):
             logger.info(
                 f'\t{solver.find_egcs(current_model,with_reacs=True,namespace=config["general"]["namespace"])}'
             )
-            
+
     step_end = time.time()
     logger.info(f"EGCs\truntime: {step_end-step_start}s\n")
 
     if results:
-        between_save(
-            current_model, MODEL_DIR, "after_egc_fix", only_modelpath
-        )
-        current_libmodel = convert_cobra_to_libsbml(current_model, 'notes')
+        between_save(current_model, MODEL_DIR, "after_egc_fix", only_modelpath)
+        current_libmodel = convert_cobra_to_libsbml(current_model, "notes")
         # in-between testing
-        between_growth_test(current_model, config, step="after_egcs")
+        if debug_growth:
+            between_growth_test(current_model, config, step="after_egcs")
         between_analysis(current_model, config, step="after_egcs")
 
     # BOF
     # ---
-    
+
     logger.info("Improve biomass objective function ...")
     step_start = time.time()
-    
+
     # BOFdat - optional
     if config["BOF"]["run_bofdat"]:
         check_bof = test_biomass_presence(current_model)
@@ -802,14 +820,14 @@ def run(configpath: Union[str, None] = None):
             )
     # check and normalise
     current_model = check_normalise_biomass(current_model)
-    
+
     step_end = time.time()
     logger.info(f"BOF\truntime: {step_end-step_start}s\n")
 
     # save model
     between_save(current_model, MODEL_DIR, "after_BOF", only_modelpath)
-    
-    # prune model 
+
+    # prune model
     # -----------
     # (remove mass unbalanced reactions to ensure model consistency)
     prune_mass_unbalanced_reacs(current_model)
@@ -824,14 +842,16 @@ def run(configpath: Union[str, None] = None):
         logger.warning(
             f"Given directory {current_sub_dir} already exists. High possibility of files being overwritten."
         )
-    current_libmodel = convert_cobra_to_libsbml(current_model, 'notes')
+    current_libmodel = convert_cobra_to_libsbml(current_model, "notes")
     current_libmodel = polish_annotations(current_libmodel, True, str(current_sub_dir))
-    current_libmodel = change_all_qualifiers(current_libmodel, config["cm-polish"]["is_lab_strain"])
+    current_libmodel = change_all_qualifiers(
+        current_libmodel, config["cm-polish"]["is_lab_strain"]
+    )
     between_save(current_libmodel, MODEL_DIR, "final_model", only_modelpath)
 
     # analysis
     ##########
-    
+
     logger.info("Analysing the final model ...")
     step_start = time.time()
 
@@ -891,21 +911,21 @@ def run(configpath: Union[str, None] = None):
         Path(MISC_DIR, "auxotrophy"),
         color_palette=config["general"]["colours"],
     )
-    
+
     step_end = time.time()
     logger.info(f"Final analysis\truntime: {step_end-step_start}s\n")
 
     total_time_e = time.time()
-    logger.info(f'Total run time: {total_time_e - total_time_s}')
+    logger.info(f"Total run time: {total_time_e - total_time_s}")
 
 
 # run for multiple models
 @implement
 def wrapper():
     """Run given settings for the CarveMe-ModelPolisher-based (CMPB) workflow on multiple models.
-    
+
     .. note::
-    
+
         This function is not yet implemented. It is a placeholder for future development.
     """
     # dev notes:

--- a/src/specimen/cmpb/workflow.py
+++ b/src/specimen/cmpb/workflow.py
@@ -67,7 +67,7 @@ logger = logging.getLogger(__name__)
 ################################################################################
 
 
-# @TODO Add debug switches to test growth on every step (Maybe also on full medium?) -> Maybe as entry point?
+# NOTE: debug_growth enables intermediate growth tests; consider extending this to full-medium intermediate tests if needed.
 # @ASK Provide the draft model directly from CarveMe only in debug mode or always? -> Is always provided already.
 # dev notes:
 #   in the run function: current_model means the cobrapy model,

--- a/src/specimen/cmpb/workflow.py
+++ b/src/specimen/cmpb/workflow.py
@@ -431,7 +431,7 @@ def run(configpath: Union[str, None] = None, debug_growth: bool = False):
 
         else:
             mes = f"No KEGG organism ID provided. Gapfilling with KEGG will be skipped."
-            raise logger.warning(mes, UserWarning)
+            logger.warning(mes)
 
         step_end = time.time()
         logger.info(f"KEGGapFiller\truntime: {step_end-step_start}s\n")


### PR DESCRIPTION
### Description
This PR addresses an inline `@TODO` left by @GwennyGit in `src/specimen/cmpb/workflow.py` regarding the inclusion of debug switches to test growth at every step. 

Previously, the CMPB workflow ran computationally expensive growth simulations at five intermediate stages unconditionally. This update introduces a `debug_growth` toggle to the `run()` entry point to optimize standard runtime, while preserving the ability to generate those intermediate reports when needed.

Tagging @cb-Hades for review as the primary maintainer!

### Key Changes
*   **Entry Point Update:** Added `debug_growth: bool = False` to the `run()` function signature.
*   **Performance Optimization:** Wrapped the intermediate `between_growth_test()` calls (after draft, gapfill, duplicate removal, ModelPolisher, and EGCs) inside `if debug_growth:` checks.
*   **Final Report Preserved:** The final growth test at the end of the pipeline remains unconditional, ensuring standard runs still produce the final growth analysis.